### PR TITLE
make compatible with Erlang OTP 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,10 @@
 # NervesHcsr04
+Library to read from the HC_SR04 ultrasonic distance sensor in an Elixir Nerves project.
 
-**TODO: Add description**
+You always need to set the correct target first, so the C files are cross-compiled with the correct target. 
 
-## Targets
+Add the dependency `{ :nerves_hcsr04, "~> 0.1.2" }` to your mix.exs, then run `mix deps.get && mix deps.compile`.
 
-Nerves applications produce images for hardware targets based on the
-`MIX_TARGET` environment variable. If `MIX_TARGET` is unset, `mix` builds an
-image that runs on the host (e.g., your laptop). This is useful for executing
-logic tests, running utilities, and debugging. Other targets are represented by
-a short name like `rpi3` that maps to a Nerves system image for that platform.
-All of this logic is in the generated `mix.exs` and may be customized. For more
-information about targets see:
+Afterwards build and upload the firmware to the device. 
 
-https://hexdocs.pm/nerves/targets.html#content
-
-## Getting Started
-
-To start your Nerves app:
-  * `export MIX_TARGET=my_target` or prefix every command with
-    `MIX_TARGET=my_target`. For example, `MIX_TARGET=rpi3`
-  * Install dependencies with `mix deps.get`
-  * Create firmware with `mix firmware`
-  * Burn to an SD card with `mix firmware.burn`
-
-## Learn more
-
-  * Official docs: https://hexdocs.pm/nerves/getting-started.html
-  * Official website: http://www.nerves-project.org/
-  * Discussion Slack elixir-lang #nerves ([Invite](https://elixir-slackin.herokuapp.com/))
-  * Source: https://github.com/nerves-project/nerves
+More detailed usage instructions are in the file `lib/nerves_hcsr04.ex` as code comments. 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Library to read from the HC_SR04 ultrasonic distance sensor in an Elixir Nerves 
 
 You always need to set the correct target first, so the C files are cross-compiled with the correct target. 
 
-Add the dependency `{ :nerves_hcsr04, "~> 0.1.2" }` to your mix.exs, then run `mix deps.get && mix deps.compile`.
+Add the dependency `{ :nerves_hcsr04, "~> 0.1.3" }` to your mix.exs, then run `mix deps.get && mix deps.compile`.
 
 Afterwards build and upload the firmware to the device. 
 

--- a/lib/nerves_hcsr04.ex
+++ b/lib/nerves_hcsr04.ex
@@ -1,7 +1,9 @@
 defmodule NervesHcsr04 do
 
+
   @moduledoc ~S"""
   Read HC-SR04 sensor (Sensor of distance, ultra sonic)
+
   Example usage:
   ```
   iex> defmodule MyGenServer do
@@ -17,20 +19,20 @@ defmodule NervesHcsr04 do
   iex> {:ok, distance} = MyGenServer.info(sensor)
   {:ok, 27.22}
   ```
-  You can use `listen` too listen event of sensor too.
+  You can use `listen` to listen event of sensor too.
   For example:
   ```
   iex> defmodule MyGenServer do
          use NervesHcsr04
          def listen({:ok, d, _port, {e, t}}) do
-           IO.puts("Success on MyGenServer")
-           IO.puts("Echo: #{e}, Trig: #{t}\n")
-           IO.puts("Distance: #{d}\n")
+           Logger.info("Success on MyGenServer")
+           Logger.info("Echo: #{e}, Trig: #{t}\n")
+           Logger.info("Distance: #{d}\n")
          end
          def listen({:error, code_error, _port, {e, t}}) do
-           IO.puts("Error on MyGenServer")
-           IO.puts("Echo: #{e}, Trig: #{t}\n")
-           IO.puts("Error: #{code_error}\n")
+           Logger.info("Error on MyGenServer")
+           Logger.info("Echo: #{e}, Trig: #{t}\n")
+           Logger.info("Error: #{code_error}\n")
          end
        end
   :ok
@@ -49,6 +51,13 @@ defmodule NervesHcsr04 do
   Echo: 8, Trig: 9
   Error: -2
   ```
+
+  The error codes are:
+    SUCCESS 0
+    ERROR_INIT_GPIO -1
+    TIMEOUT_PING -2
+    TIMEOUT_PONG -3
+    ERROR_GPIO_PIN -4
   """
 
   defmacro __using__(_opts) do
@@ -64,7 +73,8 @@ defmodule NervesHcsr04 do
       end
 
       def handle_info({port, {:data, data}}, _state) do
-        {type, echo, trig, result} = :erlang.binary_to_term(data)
+        {type, echo, trig, result} = List.first(:erlang.binary_to_term(data))
+
         states = {type, result, port, {echo, trig}}
         __MODULE__.listen(states)
         {:noreply, states}

--- a/lib/nerves_hcsr04.ex
+++ b/lib/nerves_hcsr04.ex
@@ -73,7 +73,7 @@ defmodule NervesHcsr04 do
       end
 
       def handle_info({port, {:data, data}}, _state) do
-        {type, echo, trig, result} = List.first(:erlang.binary_to_term(data))
+        {type, echo, trig, result} = :erlang.binary_to_term(data)
 
         states = {type, result, port, {echo, trig}}
         __MODULE__.listen(states)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule NervesHcsr04.MixProject do
   def project do
     [
       app: :nerves_hcsr04,
-      version: "0.1.2",
+      version: "0.1.3",
       compilers: [:elixir_make] ++ Mix.compilers(),
       description: description(),
       package: package(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule NervesHcsr04.MixProject do
   def project do
     [
       app: :nerves_hcsr04,
-      version: "0.1.1",
+      version: "0.1.2",
       compilers: [:elixir_make] ++ Mix.compilers(),
       description: description(),
       package: package(),
@@ -22,7 +22,7 @@ defmodule NervesHcsr04.MixProject do
 
   defp deps do
     [
-      {:elixir_make, "~> 0.4.1"},
+      {:elixir_make, "~> 0.6.1"},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
-  "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm", "c57508ddad47dfb8038ca6de1e616e66e9b87313220ac5d9817bc4a4dc2257b9"},
+  "elixir_make": {:hex, :elixir_make, "0.6.1", "8faa29a5597faba999aeeb72bbb9c91694ef8068f0131192fb199f98d32994ef", [:mix], [], "hexpm", "35d33270680f8d839a4003c3e9f43afb595310a592405a00afc12de4c7f55a18"},
+  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "33d7b70d87d45ed899180fb0413fb77c7c48843188516e15747e00fdecf572b6"},
 }

--- a/src/_Raspberry_Pi_Driver.c
+++ b/src/_Raspberry_Pi_Driver.c
@@ -3,52 +3,58 @@
 #include <unistd.h>
 
 #include "erl_common.c"
-#include "erl_interface.h"
 #include "ei.h"
 
 #include "Raspberry_Pi/pi_sensor.h"
 
 typedef unsigned char byte;
 
-int main(int argc, char *argv[]) {
+int main(int argc, char *argv[])
+{
 
-  if (argc != 3) {
+  if (argc != 3)
+  {
     fprintf(stderr, "Usage: %s [GPIO_ECHO] [GPIO_TRIG] \n", argv[0]);
     exit(EXIT_FAILURE);
   }
 
+  ei_init();
+
   int echo = atoi(argv[1]);
   int trig = atoi(argv[2]);
 
-  ETERM * arr[4], *tuple;
-  unsigned char buf[BUFSIZ];
+  byte input[100];
+  ei_x_buff output;
 
-  erl_init(NULL, 0);
-
-  while (read_cmd(buf) > 0) {
-
+  while (read_cmd(input) > 0)
+  {
     float distance = 0;
     int result = pi_sensor(echo, trig, &distance);
 
-    if(result == SUCCESS){
-      arr[0] = erl_mk_atom("ok");
-      arr[1] = erl_mk_int(echo);
-      arr[2] = erl_mk_int(trig);
-      arr[3] = erl_mk_float(distance);
-    } else {
-      arr[0] = erl_mk_atom("error");
-      arr[1] = erl_mk_int(echo);
-      arr[2] = erl_mk_int(trig);
-      arr[3] = erl_mk_int(result);
+    ei_x_new(&output);
+
+    if (result == SUCCESS)
+    {
+      ei_x_format(&output,
+                  "[{~a,~i,~i,~f}]",
+                  "ok",
+                  echo,
+                  trig,
+                  distance);
+    }
+    else
+    {
+      ei_x_format(&output,
+                  "[{~a,~i,~i,~i}]",
+                  "error",
+                  echo,
+                  trig,
+                  result);
     }
 
-    tuple  = erl_mk_tuple(arr, 4);
+    write_cmd(output.buff, output.index);
 
-    erl_encode(tuple, buf);
-
-    write_cmd(buf, erl_term_len(tuple));
-
-    erl_free_term(tuple);
+    ei_x_free(&output);
   }
 
   return 1;

--- a/src/_Raspberry_Pi_Driver.c
+++ b/src/_Raspberry_Pi_Driver.c
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
     if (result == SUCCESS)
     {
       ei_x_format(&output,
-                  "[{~a,~i,~i,~f}]",
+                  "{~a,~i,~i,~f}",
                   "ok",
                   echo,
                   trig,
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
     else
     {
       ei_x_format(&output,
-                  "[{~a,~i,~i,~i}]",
+                  "{~a,~i,~i,~i}",
                   "error",
                   echo,
                   trig,


### PR DESCRIPTION
I needed this for a Nerves project I'm doing but could not get it to work with a recent Erlang OTP version. So I used my very very limited C knowledge to update this useful library.

I tested it successfully with an RPi0 as target and Linux Mint 20 as development system.

It would be great if you could review and merge my changes and then update the version on Hex, so everyone can use it directly.